### PR TITLE
Fix pagination missing parameters

### DIFF
--- a/cyberwatch_api.py
+++ b/cyberwatch_api.py
@@ -112,79 +112,40 @@ class Cyberwatch_Pyhelper:
         if self.__api_secret is None:
             raise Exception("api_secret not found")
 
-    @property
-    def method(self) -> str:
-        return self.__method
-
-    @method.setter
-    def method(self, value: str):
-        if isinstance(value, str):
-            self.__method = str(value).upper()
-        else:
-            raise Exception("The type of method parameter should be a str")
-
-    @property
-    def url(self) -> str:
-        return self.__url
-
-    @url.setter
-    def url(self, value: str):
-        if isinstance(value, str):
-            self.__url = self.api_url + value
-        else:
-            raise Exception("The type of endpoint parameter should be str")
-
-    @property
-    def timeout(self) -> int:
-        return self.__timeout
-
-    @timeout.setter
-    def timeout(self, value: int):
-        if isinstance(value, int):
-            self.__timeout = value
-        else:
-            raise Exception("The type of timeout parameter should be int")
-
     def __basic_auth(self) -> requests.auth.HTTPBasicAuth:
         """
         Private method returning a BasicAuth
         """
         return requests.auth.HTTPBasicAuth(self.api_key, self.api_secret)
     
-    def api_http_request(self, url):
-        return requests.request(
-            method=self.method,
-            url=url,
-            headers=self.headers,
-            auth=self.__basic_auth(),
-            params=self.params,
-            data=self.body_params,
-            timeout=self.timeout,
-            verify=self.verify_ssl
-        )
-    
     @clear_endpoint
     def request(self, **kwargs) -> Generator[requests.models.Response, None, None]:
         """
         Only accessible method, handles every step of the API call
         """
-        self.method = kwargs.get("method")
-        self.url = kwargs.get("endpoint")
-        self.timeout = kwargs.get("timeout") or 10
-        self.params = kwargs.get("params") or {}
-        self.body_params = kwargs.get("body_params") or {}
+        if not isinstance(kwargs.get("method"), str): raise Exception("The type of endpoint parameter should be str")
+        if kwargs.get("timeout") and not isinstance(kwargs.get("timeout"), int): raise Exception("The type of timeout parameter should be int")
 
-        self.headers = {'Content-type': 'application/json'}
+        method = str(kwargs.get("method")).upper()
+        timeout = kwargs.get("timeout") or 10
+        params = kwargs.get("params") or {}
+        body_params = json.dumps(kwargs.get("body_params")) if kwargs.get("body_params") else {}
+        headers = {'Content-type': 'application/json'}
+        verify_ssl = kwargs.get("verify_ssl")
+        url = self.api_url + kwargs.get("endpoint")
 
-        if self.body_params is not None:
-            self.body_params = json.dumps(self.body_params)
-
-        self.verify_ssl = kwargs.get("verify_ssl")
-
-        response = self.api_http_request(self.url)
-        yield response
-        while "next" in response.links:
-            response = self.api_http_request(response.links["next"]["url"])
+        while url:
+            response = requests.request(
+                method=method,
+                url=url,
+                headers=headers,
+                auth=self.__basic_auth(),
+                params=params,
+                data=body_params,
+                timeout=timeout,
+                verify=verify_ssl
+            )
+            url = response.links["next"]["url"] if "next" in response.links else None
             yield response
 
 


### PR DESCRIPTION
Parameters 'data' and 'headers' were not passed in the pagination call to the API.
The API call is now in a function instead of being duplicated.