### PR TITLE
Update the default value of verify_ssl in cyberwatch-cli

### DIFF
--- a/cli/bin/__init__.py
+++ b/cli/bin/__init__.py
@@ -1,0 +1,5 @@
+def verify_ssl_value():
+    #######
+    # Set to 'False' to disable ssl verification / 'True' to activate ssl verification
+    #######
+    return False

--- a/cli/bin/airgap/download_compliance_scripts.py
+++ b/cli/bin/airgap/download_compliance_scripts.py
@@ -1,6 +1,7 @@
 from cyberwatch_api import Cyberwatch_Pyhelper
 from os.path import abspath, basename, dirname, join
 import os
+from .. import verify_ssl_value
 from .. import os as cbw_os
 import argparse
 import sys
@@ -25,7 +26,8 @@ def retrieve_compliance_scripts(os_key, repositories):
         body_params={
             "os" : str(os_key),
             "repositories" : repositories
-        }
+        },
+        verify_ssl=verify_ssl_value()
     )
     return next(apiResponse).json()
 

--- a/cli/bin/airgap/download_scripts.py
+++ b/cli/bin/airgap/download_scripts.py
@@ -1,6 +1,7 @@
 from cyberwatch_api import Cyberwatch_Pyhelper
 from os.path import abspath, basename, dirname, join
 from itertools import groupby
+from .. import verify_ssl_value
 import argparse
 import sys
 import os
@@ -30,7 +31,8 @@ done
 def retrieve_scripts(scriptID=""):
     apiResponse = Cyberwatch_Pyhelper().request(
         method="GET",
-        endpoint="/api/v2/cbw_scans/scripts/" + str(scriptID)
+        endpoint="/api/v2/cbw_scans/scripts/" + str(scriptID),
+        verify_ssl=verify_ssl_value()
     )
     return next(apiResponse).json()
 

--- a/cli/bin/airgap/upload_compliance_scripts.py
+++ b/cli/bin/airgap/upload_compliance_scripts.py
@@ -1,6 +1,7 @@
 from cyberwatch_api import Cyberwatch_Pyhelper
 from os.path import abspath, basename, dirname, join
 from itertools import groupby
+from .. import verify_ssl_value
 import argparse
 import chardet
 import sys
@@ -31,7 +32,8 @@ def upload_result_file(result_file):
         endpoint="/api/v2/cbw_scans/scripts",
         body_params={
             "output" : file_content
-        }
+        },
+        verify_ssl=verify_ssl_value()
     )
     result = next(apiResponse).json()
 

--- a/cli/bin/airgap/upload_scripts.py
+++ b/cli/bin/airgap/upload_scripts.py
@@ -2,7 +2,7 @@ from cyberwatch_api import Cyberwatch_Pyhelper
 from os.path import abspath, basename, dirname, join
 from itertools import groupby
 import argparse
-
+from .. import verify_ssl_value
 import chardet
 import sys
 import os
@@ -32,7 +32,8 @@ def upload_result_file(result_file):
         endpoint="/api/v2/cbw_scans/scripts",
         body_params={
             "output" : file_content
-        }
+        },
+        verify_ssl=verify_ssl_value()
     )
     result = next(apiResponse).json()
 

--- a/cli/bin/os.py
+++ b/cli/bin/os.py
@@ -1,4 +1,5 @@
 from cyberwatch_api import Cyberwatch_Pyhelper
+from . import verify_ssl_value
 import sys
 
 def help():
@@ -13,7 +14,8 @@ def help():
 def retrieve_os():
     apiResponse = Cyberwatch_Pyhelper().request(
         method="GET",
-        endpoint="/api/v3/os"
+        endpoint="/api/v3/os",
+        verify_ssl=verify_ssl_value()
     )
     os = []
     for page in apiResponse: 

--- a/cli/cyberwatch-cli.py
+++ b/cli/cyberwatch-cli.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
-
 from cyberwatch_api import Cyberwatch_Pyhelper
 import sys
 from bin import os, airgap
+import requests
+from urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
 def help():
     print("Usage : " + str(sys.argv[0]) + " [COMMAND] [ARGS]")


### PR DESCRIPTION
Now you can set the verify_ssl value (by default 'False') by updating the 'verify_ssl_value' function location in 'cli/bin/__init__.py'.