### PR TITLE
Cyberwatch-CLI review fix

### DIFF
--- a/cli/bin/airgap/download_compliance_scripts.py
+++ b/cli/bin/airgap/download_compliance_scripts.py
@@ -47,6 +47,7 @@ def download_compliance_scripts(os_key, repositories, destination_folder, CBW_AP
     run_script = "".join((script_dir, "/", compliance_scripts_metadata["filename"]))
     with open(run_script, "w") as filestream:
         filestream.write(compliance_scripts_metadata["script_content"])
+        os.chmod(run_script, 0o760)
     
     print("\033[A\033[A\nDownload complete ! Scripts are located in '" + str(destination_folder) + "'")
     
@@ -64,7 +65,7 @@ def manager(arguments, CBW_API, verify_ssl=False):
         help()
     
     elif arguments and arguments[0] == 'list-os':
-        cbw_os.manager(["list"])
+        cbw_os.manager(["list"], CBW_API)
 
     elif options.os is None or not options.repositories:
         print("You need to specify an OS and a list of one or many repositories to fetch the associated compliance rules.")

--- a/cli/bin/airgap/download_scripts.py
+++ b/cli/bin/airgap/download_scripts.py
@@ -53,8 +53,8 @@ def download_scripts(destination_folder, CBW_API, verify_ssl=False, with_attachm
         if target_os in ("Aix", "Linux", "Macos", "Vmware"):
             run_script_filename = join(script_dir, target_os, "run")
             with open(run_script_filename, "w") as file_stream:
-                file_stream.write(SH_EXECUTE_SCRIPT.format(" ".join(content for (os, content) in scripts)))
-                os.chmod(run_script_filename, 0o755)
+                file_stream.write(SH_EXECUTE_SCRIPT.format(" ".join(sorted([content for (os, content) in scripts], key=lambda x: (x[0] != 'I', x)))))
+                os.chmod(run_script_filename, 0o760)
 
         if target_os == "Windows":
                 run_script_filename = join(script_dir, target_os, "run.ps1")

--- a/cli/bin/airgap/upload_compliance_scripts.py
+++ b/cli/bin/airgap/upload_compliance_scripts.py
@@ -28,6 +28,7 @@ def upload_result_file(result_file, CBW_API, verify_ssl=False):
         body_params={
             "output" : file_content
         },
+        timeout=90,
         verify_ssl=verify_ssl
     )
     # If the operation is successful, the apiResponse is empty and the status code is 204

--- a/cli/bin/airgap/upload_scripts.py
+++ b/cli/bin/airgap/upload_scripts.py
@@ -28,6 +28,7 @@ def upload_result_file(result_file, CBW_API, verify_ssl=False):
         body_params={
             "output" : file_content
         },
+        timeout=90,
         verify_ssl=verify_ssl
     )
     result = next(apiResponse)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='cyberwatch_api',
-      version='0.3.5',
+      version='0.3.6',
       description='Python Api client for the Cyberwatch software',
       long_description=open('README.md').read().strip(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
This MR fixes multiples issues found during review.
- Timeout of airgap results has been increased to 90 seconds instead of 10 by default.
- Downloaded compliance script now has the 'executable' right by default
- The InfoScript.sh is now the first one executed to prevent different docker hostnames overriding the assets when 'DockerImagesScansScript.sh' is executed first.