### PR TITLE
add ping to CLI

### DIFF
--- a/cli/bin/airgap/download_scripts.py
+++ b/cli/bin/airgap/download_scripts.py
@@ -10,7 +10,7 @@ def help():
     print("Download airgap scripts.\n")
     print("{: >23} \t {: >20} \t{}".format("ARGS", "DEFAULT", "DESCRIPTION"))
     print("{: >23} \t {: >20} \t{}".format("---", "---", "---"))
-    print("{: >23} \t {: >20} \t{}".format("--no-attachment", "False", "-"))
+    print("{: >23} \t {: >20} \t{}".format("--add-attachment", "False", "Download the Windows cab file"))
     print("{: >23} \t {: >20} \t{}".format("--dest-dir", "cyberwatch-airgap", "Destination folder where to put the downloaded scripts"))
     print("\n")
 
@@ -95,7 +95,7 @@ def download_individual_script(scriptID, base_dir, CBW_API, with_attachment=Fals
 def manager(arguments, CBW_API, verify_ssl=False):
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--no-attachment", action="store_false")
+    parser.add_argument("--add-attachment", action="store_false")
     parser.add_argument("--dest-dir", default="cyberwatch-airgap")
     parser.add_argument("help", nargs="?")
     options = parser.parse_args(arguments)
@@ -103,4 +103,4 @@ def manager(arguments, CBW_API, verify_ssl=False):
     if arguments and arguments[0] == "help":
         help()
     else:
-        download_scripts(options.dest_dir, CBW_API, verify_ssl, options.no_attachment)
+        download_scripts(options.dest_dir, CBW_API, verify_ssl, options.add_attachment)

--- a/cli/cyberwatch-cli
+++ b/cli/cyberwatch-cli
@@ -25,7 +25,21 @@ def help():
     print("{: >15} \t {}".format("---", "---"))
     print("{: >15} \t {}".format("os", "Manage cyberwatch operating systems"))
     print("{: >15} \t {}".format("airgap", "Interact with the airgap interface"))
+    print("{: >15} \t {}".format("ping", "Ping the Cyberwatch API to validate the connexion"))
     print("\n")
+
+def ping(CBW_API, verify_ssl=False):
+    apiResponse = CBW_API.request(
+        method="GET",
+        endpoint="/api/v3/ping",
+        verify_ssl=verify_ssl
+    )
+    print("Trying to ping Cyberwatch API...")
+    response = next(apiResponse).json()
+    print(response)
+    if response.get("error") is not None:
+        print("Failed ping to Cyberwatch API, exiting...")
+        sys.exit(1)
 
 arguments = sys.argv[1:]
 
@@ -54,9 +68,13 @@ try:
 
     if not arguments or arguments[0] == "help":
         help()
+    elif arguments[0] == "ping":
+        ping(CBW_API, VERIFY_SSL)
     elif arguments[0] == "os":
+        ping(CBW_API, VERIFY_SSL)
         os.manager(arguments[1:], CBW_API, VERIFY_SSL)
     elif arguments[0] == "airgap":
+        ping(CBW_API, VERIFY_SSL)
         airgap.manager(arguments[1:], CBW_API, VERIFY_SSL)
     else:
         print("ERROR : '" + str(arguments[0]) + "' is not a valid command\n---", file=sys.stderr)


### PR DESCRIPTION
If you happen to have wrong API keys, CLI throws random errors depending on the options you call.

Before using options like "airgap" or "os", the cyberwatch-cli now tries to ping the API to make sure everything is ok before requesting Cyberwatch

Also changed "--no-attachment" to "--add-attachment" as it makes more sense as the value is "False" by default